### PR TITLE
revert packets_to_write >= packets_written

### DIFF
--- a/flasher/memory.py
+++ b/flasher/memory.py
@@ -101,9 +101,9 @@ def write_memory(ecu, payload, flash_start, flash_size, progress_callback=False)
 	packets_to_write = int(flash_size/254)
 	packets_written = 0
 
-	while packets_to_write > packets_written:
+	while packets_to_write >= packets_written:
 		if (progress_callback):
-			progress_callback.title('Packet {}/{}'.format(packets_written+1, packets_to_write))
+			progress_callback.title('Packet {}/{}'.format(packets_written, packets_to_write))
 
 		payload_packet_start = packets_written*254
 		payload_packet_end = payload_packet_start+254


### PR DESCRIPTION
this causes progress bar issues when the flash size is rounded to 254 bytes but it enables simk41 v6 flashing